### PR TITLE
修复百度地图瓦片行列号列号顺序问题导致的定位不精准

### DIFF
--- a/Mod/EarthMod/Com.lua
+++ b/Mod/EarthMod/Com.lua
@@ -15,7 +15,7 @@ ComVar = {
 	DrawAllMap = nil; -- 开启全部自动绘制
 	Draw3DBuilding = nil; -- 是否绘制地上建筑
 	-- gis
-	factor = 1.19; -- 地图缩放比例
+	factor = 1.19; -- 地图缩放比例（百度地图自动设置为1）
 	FloorLevel = 5; -- 绘制地图层层高：草地层
 	buildLevelMax = 60; -- 绘制地图层层高：草地层
     buildLevelHeight = 4; -- 每层建筑高度

--- a/Mod/EarthMod/MapGeography.lua
+++ b/Mod/EarthMod/MapGeography.lua
@@ -154,8 +154,8 @@ function MapGeography:bddeg2tile(lon, lat)
     local x,y=LatLng2Mercator(lon,lat)
     local xtile=math.floor((x*2^(self.zoomLv-18))/TILE_SIZE)
     local ytile=math.floor((y*2^(self.zoomLv-18))/TILE_SIZE)
-    echo("convert:");echo({x, y, lon, lat, xtile, ytile})
-    echo({self.zoomLv,TILE_SIZE})
+    -- echo("convert:");echo({x, y, lon, lat, xtile, ytile})
+    -- echo({self.zoomLv,TILE_SIZE})
     return xtile,ytile
 end
 
@@ -179,7 +179,7 @@ end
 function MapGeography:bdtilepiexl2coord(tile_x, tile_y, piexl_x, piexl_y, isGis)
     local x=(tile_x*TILE_SIZE+piexl_x)/(2^(self.zoomLv-18))
     local y=(tile_y*TILE_SIZE+piexl_y)/(2^(self.zoomLv-18))
-    local lat_deg,lon_deg = Mercator2LatLng(x,y)
+    local lon_deg,lat_deg = Mercator2LatLng(x,y)
     if isGis then return tostring(lon_deg), tostring(lat_deg) end
     return {lon = lon_deg, lat = lat_deg}
 end
@@ -319,6 +319,7 @@ function MapGeography:getGPo(x,y,z)
     local dx = (x - tpack.firstBlockPo.x) / self.tileSize + tpack.beginPo.x
     local dz = tpack.beginPo.y - (z - tpack.firstBlockPo.z) / self.tileSize + 1
     local a,b,c,d = self:getTilePo(dx,dz)
+    echo("getGPo:");echo({self:pixel2deg(a,b,c,d,true)})
     return self:pixel2deg(a,b,c,d,true)
 end
 
@@ -330,9 +331,9 @@ function MapGeography:getParaPo(lon,lat)
         lat = lon.lat;lon = lon.lon
     end
     local tileX,tileZ,x,z = self:deg2pixel(lon,lat,true)
-    -- echo(lon);echo(lat);echo("transPara:");echo(tileX);echo(tileZ);echo(x);echo(z)
     local dx = (tileX - tpack.beginPo.x) * self.tileSize + x + tpack.firstBlockPo.x
     local dz = (tpack.beginPo.y - tileZ + 1) * self.tileSize - z + tpack.firstBlockPo.z
+    echo("getParaPo:");echo({lon,lat,tileX,tileZ,x,z,dx,dz})
     return {x = math.round(dx),y = tpack.firstBlockPo.y,z = math.round(dz)}
 end
 -- GPS偏移纠正到百度

--- a/Mod/EarthMod/MapGeography.lua
+++ b/Mod/EarthMod/MapGeography.lua
@@ -21,9 +21,12 @@ MapGeography.zoomN = nil
 
 -- 初始化MapGeography，可以传入指定的图片尺寸和缩放比例，否则自动判断
 function MapGeography:ctor(zoom)
-	self.tileSize = math.ceil(TILE_SIZE * ComVar.factor)
-    local ZOOM_LV -- OSM级数17 百度为18
-    if ComVar.usingMap == "OSM" then ZOOM_LV = 17 elseif ComVar.usingMap == "BAIDU" then ZOOM_LV = 18 end
+  local ZOOM_LV -- OSM级数17 百度为18
+  if ComVar.usingMap == "OSM" then ZOOM_LV = 17 elseif ComVar.usingMap == "BAIDU" then
+    ZOOM_LV = 18
+    ComVar.factor = 1 -- 百度地图18级已经是1:1比例了
+  end
+  self.tileSize = math.ceil(TILE_SIZE * ComVar.factor)
 	self.zoomLv = zoom or ZOOM_LV
 	self.zoomN = 2 ^ self.zoomLv
     curInstance = self
@@ -32,7 +35,10 @@ end
 -- 计算瓦片位置(返回行列号和像素点坐标)
 function MapGeography:getTilePo(tx,ty)
     local Xt,Yt = math.floor(tx), math.floor(ty)
-    local Xp,Yp = math.floor((tx - Xt) * self.tileSize), math.floor((ty - Yt) * self.tileSize)
+    local Xp,Yp = nil,nil
+    if ComVar.usingMap == "OSM" then
+      Xp,Yp = math.floor((tx - Xt) * self.tileSize), math.floor((ty - Yt) * self.tileSize)
+    else Xp,Yp = math.floor((tx - Xt) * TILE_SIZE), math.floor((ty - Yt) * TILE_SIZE) end
     return Xt, Yt, Xp, Yp
 end
 
@@ -43,7 +49,7 @@ function MapGeography:deg2pixelOsm(lon, lat, isGis)
     local xtile = self.zoomN * ((lon_deg + 180) / 360)
     local ytile = self.zoomN * (1 - (math.log(math.tan(lat_rad) + (1 / math.cos(lat_rad))) / math.pi)) / 2
     if isGis then
-        return math.floor(xtile * TILE_SIZE % TILE_SIZE + 0.5),math.floor(ytile * TILE_SIZE % TILE_SIZE + 0.5)
+        return math.floor(xtile * self.tileSize % self.tileSize + 0.5),math.floor(ytile * self.tileSize % self.tileSize + 0.5)
     end
     return self:getTilePo(xtile, ytile)
 end
@@ -58,8 +64,8 @@ end
 
 -- 瓦片行列式转经纬度(参数：瓦片ID，瓦片中所在像素位置，缩放级数)
 function MapGeography:pixel2degOsm(tileX, tileY, pixelX, pixelY, isGis)
-    local lon_deg = (tileX + pixelX / TILE_SIZE) / self.zoomN * 360.0 - 180.0;
-    local lat_rad = math.atan(math.sinh(math.pi * (1 - 2 * (tileY + pixelY/TILE_SIZE) / self.zoomN)))
+    local lon_deg = (tileX + pixelX / self.tileSize) / self.zoomN * 360.0 - 180.0;
+    local lat_rad = math.atan(math.sinh(math.pi * (1 - 2 * (tileY + pixelY/self.tileSize) / self.zoomN)))
     local lat_deg = lat_rad * 180.0 / math.pi
     if isGis then return tostring(lon_deg), tostring(lat_deg) end
     return {lon = lon_deg, lat = lat_deg}
@@ -317,11 +323,15 @@ function MapGeography:getGPo(x,y,z)
     end
     local tpack = TileManager.GetInstance()
     local dx = (x - tpack.firstBlockPo.x) / self.tileSize + tpack.beginPo.x
-    local dz = tpack.beginPo.y - (z - tpack.firstBlockPo.z) / self.tileSize + 1
+    local dz = nil
+    if ComVar.usingMap == "BAIDU" then dz = (z - tpack.firstBlockPo.z) / self.tileSize + tpack.beginPo.y
+    else dz = tpack.beginPo.y - (z - tpack.firstBlockPo.z) / self.tileSize + 1 end
     local a,b,c,d = self:getTilePo(dx,dz)
-    echo("getGPo:");echo({self:pixel2deg(a,b,c,d,true)})
+    -- echo("getGPo:");echo({self:pixel2deg(a,b,c,d,true)})
+    echo({x=x,y=y,z=z})
     return self:pixel2deg(a,b,c,d,true)
 end
+
 
 -- gps经纬度转parancraft坐标系 -32907218 5 15222780
 function MapGeography:getParaPo(lon,lat)
@@ -332,15 +342,20 @@ function MapGeography:getParaPo(lon,lat)
     end
     local tileX,tileZ,x,z = self:deg2pixel(lon,lat,true)
     local dx = (tileX - tpack.beginPo.x) * self.tileSize + x + tpack.firstBlockPo.x
-    local dz = (tpack.beginPo.y - tileZ + 1) * self.tileSize - z + tpack.firstBlockPo.z
-    echo("getParaPo:");echo({lon,lat,tileX,tileZ,x,z,dx,dz})
+    local dz = nil
+    if ComVar.usingMap == "BAIDU" then dz = (tileZ - tpack.beginPo.y) * self.tileSize + z + tpack.firstBlockPo.z
+    else dz = (tpack.beginPo.y - tileZ + 1) * self.tileSize - z + tpack.firstBlockPo.z end
+    -- echo("getParaPo:");echo({lon,lat,tileX,tileZ,x,z})
+    echo({x = math.round(dx),y = tpack.firstBlockPo.y,z = math.round(dz)})
     return {x = math.round(dx),y = tpack.firstBlockPo.y,z = math.round(dz)}
 end
+
 -- GPS偏移纠正到百度
 function MapGeography:gpsToBaidu(gps_lon,gps_lat)
     local lon,lat = MapGeography.gcj02tobd09(MapGeography.wgs84togcj02(gps_lon,gps_lat))
     return lon,lat
 end
+
 -- 百度经纬度转GPS经纬度（一般用不上）
 function MapGeography:baiduToGps(gps_lon,gps_lat)
     local lon,lat = MapGeography.gcj02towgs84(MapGeography.bd09togcj02(gps_lon,gps_lat))

--- a/Mod/EarthMod/TileManager.lua
+++ b/Mod/EarthMod/TileManager.lua
@@ -69,7 +69,8 @@ end
 function TileManager:init(para) -- 左下行列号，右上行列号，焦点坐标（左下点），瓦片大小
 	self.tileSize = para.tileSize or TILE_SIZE
 	self.col = para.rid - para.lid + 1
-	self.row = para.bid - para.tid + 1
+	if ComVar.usingMap == "BAIDU" then self.row = para.tid - para.bid + 1
+	else self.row = para.bid - para.tid + 1 end
 	self.oPo = {x = para.bx - (self.col - 1) * self.tileSize * 0.5,y = para.by,z = para.bz - (self.row - 1) * self.tileSize * 0.5}
 	self.idHL = {col=para.lid,row=para.bid} -- 记录左下角行列式
 	self.beginPo = {x = para.lid, y = para.bid}
@@ -88,7 +89,9 @@ end
 -- 扩充校园；传入新的 firstPo,lastPo,lid,bid,rid,tid 调整瓦片数据
 function TileManager:reInit(para)
 	self.col = para.rid - para.lid + 1
-	self.row = para.bid - para.tid + 1
+	-- self.row = para.bid - para.tid + 1
+	if ComVar.usingMap == "BAIDU" then self.row = para.tid - para.bid + 1
+	else self.row = para.bid - para.tid + 1 end
 	self.count = self.col * self.row
 	self.size = {width = self.tileSize * self.col,height = self.tileSize * self.row}
 	self.firstGPo = para.firstPo -- 传入地理位置信息
@@ -98,7 +101,8 @@ function TileManager:reInit(para)
 	-- echo("reInit:convert")
 	-- echo(para)
 	-- echo(self.idHL)
-	self.deltaHL = {col=para.lid - self.idHL.col,row=self.idHL.row - para.bid} -- 行列差 col:x row:y
+	if ComVar.usingMap == "BAIDU" then self.deltaHL = {col=para.lid - self.idHL.col,row=para.bid - self.idHL.row}
+	else self.deltaHL = {col=para.lid - self.idHL.col,row=self.idHL.row - para.bid} end
 	-- echo(self.deltaHL)
 	self.idHL = {col=para.lid,row=para.bid}
 	local fbPo = {x = self.firstBlockPo.x + self.deltaHL.col * self.tileSize,y = self.firstBlockPo.y,z = self.firstBlockPo.z + self.deltaHL.row * self.tileSize}
@@ -195,7 +199,9 @@ function TileManager:getDrawPosition(idx,idy)
 	if idx < 1 or idx > self.col or idy < 1 or idy > self.row then return nil end
 	local po = {x = self.oPo.x + (idx - 1) * self.tileSize,y = self.oPo.y,z = self.oPo.z + (idy - 1) * self.tileSize}
 	local curID = idx + (idy - 1) * self.col
-	local ranksID = {x = self.beginPo.x + idx - 1,y = self.beginPo.y - idy + 1} -- 行列号
+	local ranksID = nil -- 行列号
+	if ComVar.usingMap == "BAIDU" then ranksID = {x = self.beginPo.x + idx - 1,y = self.beginPo.y + idy - 1}
+	else ranksID = {x = self.beginPo.x + idx - 1,y = self.beginPo.y - idy + 1} end
 	if self.tiles[curID] then
 		return self.tiles[curID].po,self.tiles[curID]
 	else

--- a/Mod/EarthMod/gisCommand.lua
+++ b/Mod/EarthMod/gisCommand.lua
@@ -67,7 +67,7 @@ Commands["gis"] = {
 				cache = 'false';
 			end
 
-			gisCommand.gis = Tasks.gisToBlocks:new({options=optionsType,minlat=maxlat,minlon=minlon,maxlat=minlat,maxlon=maxlon,cache=cache});
+			gisCommand.gis = Tasks.gisToBlocks:new({options=optionsType,minlat=minlat,minlon=minlon,maxlat=maxlat,maxlon=maxlon,cache=cache});
 			-- echo("got cordi:");echo({minlat=minlat,minlon=minlon,maxlat=maxlat,maxlon=maxlon})
 			gisCommand.gis:Run();
 			return;

--- a/Mod/EarthMod/gisToBlocksTask.lua
+++ b/Mod/EarthMod/gisToBlocksTask.lua
@@ -1202,6 +1202,7 @@ function gisToBlocks:initWorld()
 		getOsmService.dbottom = gisToBlocks.dbottom;
 		getOsmService.zoom = self.zoom;
 		-- 根据minlat和minlon计算出左下角的瓦片行列号坐标
+		echo("initWorld: ")
 		gisToBlocks.tile_MIN_X , gisToBlocks.tile_MIN_Y   = MapGeography.GetInstance():deg2tile(self.minlon,self.minlat);
 		-- 根据maxlat和maxlon计算出右上角的瓦片行列号坐标
 		gisToBlocks.tile_MAX_X , gisToBlocks.tile_MAX_Y   = MapGeography.GetInstance():deg2tile(self.maxlon,self.maxlat);

--- a/Mod/EarthMod/gisToBlocksTask.lua
+++ b/Mod/EarthMod/gisToBlocksTask.lua
@@ -1260,6 +1260,7 @@ function gisToBlocks:refreshPlayerInfo()
 			local player_latLon = MapGeography.GetInstance():getGPo(x, y, z);
 			local ro,str = TileManager.GetInstance():getForward(true)
 			local lon,lat,ron = math.floor(player_latLon.lon * 10000) / 10000,math.floor(player_latLon.lat * 10000) / 10000,math.floor(ro * 100) / 100
+			-- echo("set map loc: ");echo(player_latLon)
 			SelectLocationTask.setPlayerCoordinate(player_latLon.lon, player_latLon.lat);
 			if NetManager.connectState == "client" then 
 				-- 如果当前运行的是客户端,则将人物位置信息发送给服务器


### PR DESCRIPTION
修复百度地图瓦片行列号列号顺序问题导致的定位不精准